### PR TITLE
Add Docker setup and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Build React client
+FROM node:18 AS client-build
+WORKDIR /client
+COPY client/package*.json ./
+RUN npm ci
+COPY client ./
+RUN npm run build
+
+# Build Python backend and final image
+FROM python:3.11-slim
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY server/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy backend code
+COPY server/ ./
+
+# Copy built frontend
+COPY --from=client-build /client/build ./client_build
+
+# Copy start script
+COPY start.sh ./
+
+EXPOSE 8000
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@ This repository contains both the React frontend and FastAPI backend for the Int
 - `server/` – FastAPI backend originally from `InterviewappBE`.
 
 Each directory retains its own dependencies and deployment configuration.
+
+## Docker Deployment
+
+The provided `Dockerfile` builds the React frontend and serves it alongside the
+FastAPI backend. Railway reads `railway.json` to build and start the container.
+
+```bash
+docker build -t interviewapp .
+docker run -p 8000:8000 interviewapp
+```

--- a/client/check_paths.js
+++ b/client/check_paths.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+const required = ['server.js', 'public', 'src'];
+for (const item of required) {
+  if (!fs.existsSync(path.join(__dirname, item))) {
+    throw new Error(`Missing ${item}`);
+  }
+}
+console.log('Paths OK');

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,4 @@
+{
+  "build": "docker build -t interviewapp .",
+  "start": "docker run -p $PORT:8000 interviewapp"
+}

--- a/server/main.py
+++ b/server/main.py
@@ -14,6 +14,8 @@ from bs4 import BeautifulSoup
 
 from fastapi import FastAPI, HTTPException, Depends, Path, Header, Query, Body
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from dotenv import load_dotenv
 from alembic import command
@@ -109,6 +111,15 @@ from openai_client import client
 
 app.include_router(users_router)
 app.include_router(policies_router)
+
+# Serve built React frontend if present
+frontend_dir = os.path.join(os.path.dirname(__file__), "client_build")
+if os.path.isdir(frontend_dir):
+    app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")
+
+    @app.get("/{full_path:path}", include_in_schema=False)
+    async def spa_catchall(full_path: str):
+        return FileResponse(os.path.join(frontend_dir, "index.html"))
 
 # Ashby API Key
 ASHBY_API_KEY = os.getenv("ASHBY_API_KEY")

--- a/server/tests/test_imports.py
+++ b/server/tests/test_imports.py
@@ -1,0 +1,14 @@
+import importlib.util
+
+MODULES = [
+    "server.main",
+    "server.ashbyapi",
+    "server.deps",
+    "server.openai_client",
+    "server.routers.users",
+    "server.routers.policies",
+]
+
+def test_modules_importable():
+    for m in MODULES:
+        assert importlib.util.find_spec(m) is not None, f"Cannot import {m}"

--- a/server/tests/test_node_paths.py
+++ b/server/tests/test_node_paths.py
@@ -1,0 +1,4 @@
+import subprocess
+
+def test_node_paths():
+    subprocess.check_call(['node', 'client/check_paths.js'])

--- a/server/tests/test_static.py
+++ b/server/tests/test_static.py
@@ -1,0 +1,5 @@
+import os
+
+def test_frontend_path():
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'client_build')
+    assert os.path.basename(path) == 'client_build'

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}


### PR DESCRIPTION
## Summary
- add Dockerfile and `railway.json` for Railway deployment
- serve built React app from FastAPI
- add start script
- verify key modules and paths with Python/Node tests
- document Docker usage in README

## Testing
- `python -m py_compile $(git ls-files "server/*.py" "server/routers/*.py")`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859ab73bc94832e94d2d11c6a285e0a