### PR TITLE
Fix undefined get_db in FastAPI dependencies

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -23,7 +23,7 @@ from alembic.config import Config
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from deps import engine, SessionLocal
+from deps import engine, SessionLocal, get_db
 
 # --- Model and Schema Imports ---
 # It's cleaner to group these


### PR DESCRIPTION
## Summary
- import `get_db` dependency for FastAPI handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a573a3e1c832e83f7cbdfffd4183c