### PR TITLE
Fix Railway start command

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -3,6 +3,6 @@
     "command": "docker build -t interviewapp ."
   },
   "start": {
-    "command": "docker run -p $PORT:8000 interviewapp"
+    "command": "./start.sh"
   }
 }


### PR DESCRIPTION
## Summary
- run start.sh directly instead of nested docker run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a5db42d18832eb6fdde1580ae4b88