### PR TITLE
Fix default uvicorn port comment

### DIFF
--- a/server/Mainpy.txt
+++ b/server/Mainpy.txt
@@ -1532,4 +1532,4 @@ with SessionLocal() as db:
 if __name__ == "__main__":
     import uvicorn
     logging.info("Starting the FastAPI server...")
-    uvicorn.run("main:app", host="0.0.0.0", port=5000)
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- fix example uvicorn port in `Mainpy.txt` so it uses 8000

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a65dcd774832ea8d621ed037a8637