### PR TITLE
Fix reserved attribute name in ScorecardEntry model

### DIFF
--- a/server/ashbyapi.py
+++ b/server/ashbyapi.py
@@ -195,7 +195,7 @@ def process_scorecards(db: Session, application_id: str, candidate_id: uuid.UUID
                 entry.comments = item.get("comment")
                 entry.interviewer_id = interviewer_id
                 entry.submitted_at = submitted_at
-                entry.metadata = {"scorecard_name": sc_name}
+                entry.metadata_json = {"scorecard_name": sc_name}
                 db.add(entry)
     db.commit()
 

--- a/server/models.py
+++ b/server/models.py
@@ -140,7 +140,7 @@ class ScorecardEntry(Base):
     comments = Column(Text, nullable=True)
     interviewer_id = Column(String, nullable=True)
     submitted_at = Column(DateTime, nullable=True)
-    metadata = Column(JSON, nullable=True)
+    metadata_json = Column(JSON, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
     # Relationship


### PR DESCRIPTION
## Summary
- rename `metadata` field to `metadata_json` in `ScorecardEntry`
- update Ashby sync logic to use the new field name
- run tests from repository root

## Testing
- `pytest -q server/tests`

------
https://chatgpt.com/codex/tasks/task_e_685a8dda8168832e8d2b7919c9c72e4e