### PR TITLE
Fix missing BaseModel import

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI, HTTPException, Depends, Path, Header, Query, Body
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- import BaseModel and Field in FastAPI main app

## Testing
- `pip install -q -r server/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a8f303704832eb9500680d5570b4e