### PR TITLE
Add Procfile to specify start script

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bash start.sh


### PR DESCRIPTION
## Summary
- add `Procfile` for Railway/Nixpacks build to execute `start.sh`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5788c9c8832e95871cc02c49ed99