### PR TITLE
Fix React static files and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,20 @@ FastAPI backend. Railway reads `railway.json` to build and start the container.
 docker build -t interviewapp .
 docker run -p 8000:8000 interviewapp
 ```
+
+## Troubleshooting 502 Errors
+
+If you see `502 Bad Gateway` responses for `/` or `favicon.ico` after deployment,
+ensure the backend is binding to `0.0.0.0` and that the built React files are
+mounted correctly:
+
+1. **Server Host** – the start script runs:
+
+   ```bash
+   uvicorn main:app --host 0.0.0.0 --port $PORT
+   ```
+
+   Confirm your process manager executes this command.
+
+2. **Static Files** – `server/main.py` mounts the `client_build` directory using
+   FastAPI's `StaticFiles` so that `/` returns `index.html` from the React build.

--- a/server/main.py
+++ b/server/main.py
@@ -26,19 +26,6 @@ from sqlalchemy.orm import Session
 
 from deps import engine, SessionLocal, get_db
 
-# --- FastAPI setup ---
-app = FastAPI()
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-# ✅ Serve React frontend
-app.mount("/", StaticFiles(directory="client_build", html=True), name="static")
 
 # --- Model and Schema Imports ---
 from models import (

--- a/server/tests/test_start_host.py
+++ b/server/tests/test_start_host.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_start_uses_public_host():
+    start_path = Path(__file__).resolve().parents[2] / "start.sh"
+    content = start_path.read_text()
+    assert "--host 0.0.0.0" in content


### PR DESCRIPTION
## Summary
- serve frontend from a single FastAPI instance
- document how to resolve 502 errors due to host/React build
- test that start script binds to 0.0.0.0

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5a562cdc832eb2cfaf29182a5a49